### PR TITLE
replaced dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 ## Project directory
 
-- Undestanding
+- Understanding
   - [Specification](https://github.com/solid/solid-spec)
   - [Talks](https://github.com/solid/talks)
-  - [Tutorials](https://bit.lu/solid-tutorial)
+  - [Tutorials](https://melvincarvalho.gitbooks.io/solid-tutorials/content/solid_spec.html)
 
 - Implementing
   - [Sign-up/Login application](https://github.com/solid/solid-signup)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Understanding
   - [Specification](https://github.com/solid/solid-spec)
   - [Talks](https://github.com/solid/talks)
-  - [Tutorials](https://melvincarvalho.gitbooks.io/solid-tutorials/content/solid_spec.html)
+  - [Tutorials](https://melvincarvalho.gitbooks.io/solid-tutorials/content/index.html)
 
 - Implementing
   - [Sign-up/Login application](https://github.com/solid/solid-signup)


### PR DESCRIPTION
Neither https://bit.lu/solid-tutorial nor http://bit.lu/solid-tutorial worked !
I replaced it by only tutorial content I'm aware of:
https://melvincarvalho.gitbooks.io/solid-tutorials/content/solid_spec.html