### PR TITLE
Add solid:notification property.

### DIFF
--- a/proposals/notifications.md
+++ b/proposals/notifications.md
@@ -53,16 +53,16 @@ All RDF examples are written in Turtle syntax.
 
 An inbox container must be discoverable via the `solid:inbox` property, and
 should be instances of `solid:Inbox`. Each notification can be discovered via
-`ldp:contains` relations. Notifications that are of LDP RDF Source should be
-instances of `solid:Notification`. Although neither `solid:Inbox` or
-`solid:Notification` is ultimately required to discover inboxes or
-notifications, it is good practice to instantiate resources for the purpose of
-data integrity and reuse. An example:
+`solid:notification` (or `ldp:contains` for LDP based applications) relations.
+Notifications that are of LDP RDF Source should be instances of
+`solid:Notification`. Although neither `solid:Inbox` or `solid:Notification` is
+ultimately required to discover inboxes or notifications, it is good practice to
+instantiate resources for the purpose of data integrity and reuse. An example:
 
 ```
 <https://example.org/profile> solid:inbox <https://example.net/inbox/> .
 <https://example.net/inbox/> a solid:Inbox .
-<https://example.net/inbox/> ldp:contains <https://example.net/inbox/abc123> .
+<https://example.net/inbox/> solid:notification <https://example.net/inbox/abc123> .
 <https://example.net/inbox/abc123> a solid:Notification .
 ```
 


### PR DESCRIPTION
* Decouples the Solid inbox vocabulary from LDP.
* The vocabulary for Solid inboxes/notifications is a bit more consistent i.e., going from `solid:inbox` to `solid:Inbox`, and then `solid:notification` to `solid:Notification`.