### PR TITLE
Remove not found link to solid-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ to each other through a shared filesystem, and the Web is that filesystem.
 
 - Implementing
   - [Sign-up/Login application](https://github.com/solid/solid-signup)
-  - [Solid Server Test suite](https://github.com/solid/solid-tests)
+  - Solid Server Test suite
 
 - Community
   - [Server implementations](https://github.com/solid/solid-platform)


### PR DESCRIPTION
I'm not sure if you guys need to open the repository solid-tests, I try to find it
with another name but I failed. If this is something which doesn't have a repository yet, this pull request
make sense.