### PR TITLE
Updating all files to link to solidproject.org

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 # Contributors to the Solid project
 
 The Solid community wants to acknowledge the hard work and dedication put in by many people, several of whom are listed below.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 # Contributors to the Solid project
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 Copyright 2017 - present
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 Copyright 2017 - present
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 # Solid
 
 [![](https://img.shields.io/badge/project-Solid-7C4DFF.svg?style=flat-square)](https://github.com/solid/solid)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 # Solid
 

--- a/proposals/app-discovery.md
+++ b/proposals/app-discovery.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 # Solid application configuration/preferences discovery (Draft)
 
 The following describes app configuration discovery in the Solid framework 

--- a/proposals/app-discovery.md
+++ b/proposals/app-discovery.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 # Solid application configuration/preferences discovery (Draft)
 

--- a/proposals/auth-webid-rsa.md
+++ b/proposals/auth-webid-rsa.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 ### WebID-RSA
 
 WebID-RSA is somewhat similar to WebID-TLS, in that a public RSA key is

--- a/proposals/auth-webid-rsa.md
+++ b/proposals/auth-webid-rsa.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 ### WebID-RSA
 

--- a/proposals/contacts-footprint.html
+++ b/proposals/contacts-footprint.html
@@ -9,6 +9,7 @@
     <meta http-equiv="Content-Type" content="text/html" />
   </head>
   <body>
+    <blockquote>This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.</blockquote>
     <address>
       Tim Berners-Lee<br />
       Date: 2013-03-13 last change: $Date: 2016/08/26 17:04:56 $<br />

--- a/proposals/contacts-footprint.html
+++ b/proposals/contacts-footprint.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Content-Type" content="text/html" />
   </head>
   <body>
-    <blockquote>This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.</blockquote>
+  <blockquote>This is an archived, legacy repository that is no longer actively maintained. Please visit the <a href="https://solidproject.org/">official Solid website</a> instead.</blockquote>
     <address>
       Tim Berners-Lee<br />
       Date: 2013-03-13 last change: $Date: 2016/08/26 17:04:56 $<br />

--- a/proposals/data-discovery.md
+++ b/proposals/data-discovery.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 # Solid Application Data Discovery
 
 The following describes application data discovery in the Solid framework

--- a/proposals/data-discovery.md
+++ b/proposals/data-discovery.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 # Solid Application Data Discovery
 

--- a/proposals/notifications.md
+++ b/proposals/notifications.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 # Solid inboxes and notifications
 
 **Note:** The main notification spec has moved to:

--- a/proposals/notifications.md
+++ b/proposals/notifications.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 # Solid inboxes and notifications
 

--- a/proposals/patch-directions.md
+++ b/proposals/patch-directions.md
@@ -1,4 +1,5 @@
-
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+>
 # Directions for patch distribution
 
 Currently (2017-01) the solid code sends patches -- notification

--- a/proposals/patch-directions.md
+++ b/proposals/patch-directions.md
@@ -1,5 +1,5 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
->
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
+
 # Directions for patch distribution
 
 Currently (2017-01) the solid code sends patches -- notification

--- a/proposals/server-capability-discovery.md
+++ b/proposals/server-capability-discovery.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 ## Server Capability Discovery
 
 (Proposed addition to the [Recommendations for Client App Implementation](https://github.com/solid/solid-spec#recommendations-for-server-implementations) section of the Solid specs.)

--- a/proposals/server-capability-discovery.md
+++ b/proposals/server-capability-discovery.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 ## Server Capability Discovery
 

--- a/proposals/webid-oidc/README.md
+++ b/proposals/webid-oidc/README.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 # WebID-OIDC spec proposal
 

--- a/proposals/webid-oidc/README.md
+++ b/proposals/webid-oidc/README.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 # WebID-OIDC spec proposal
 
 Moved to https://github.com/solid/webid-oidc-spec

--- a/proposals/webid-oidc/decentralized-auth-glossary.md
+++ b/proposals/webid-oidc/decentralized-auth-glossary.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 # Decentralized Authentication Glossary
 

--- a/proposals/webid-oidc/decentralized-auth-glossary.md
+++ b/proposals/webid-oidc/decentralized-auth-glossary.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 # Decentralized Authentication Glossary
 
 Moved to https://github.com/solid/webid-oidc-spec#decentralized-authentication-glossary

--- a/proposals/webid-oidc/example-workflow.md
+++ b/proposals/webid-oidc/example-workflow.md
@@ -1,4 +1,4 @@
-> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+> This is an archived, legacy repository that is no longer actively maintained. Please visit the [official Solid website](https://solidproject.org/) instead.
 
 # WebID-OIDC Detailed Sign In Workflow
 

--- a/proposals/webid-oidc/example-workflow.md
+++ b/proposals/webid-oidc/example-workflow.md
@@ -1,3 +1,5 @@
+> This Repo is a Legacy Repo and no longer actively maintained. Please visit [Solid's official website](https://solidproject.org/) instead.
+
 # WebID-OIDC Detailed Sign In Workflow
 
 Moved to https://github.com/solid/webid-oidc-spec/blob/master/example-workflow.md


### PR DESCRIPTION
Allowing us to archive github.com/solid/solid, as it isn't maintained anymore. (Per the discussion in https://github.com/solid/solid/pull/256, and the Solid Team's approval of archiving this repo https://www.w3.org/community/solid/wiki/Meetings#2020-09-02).

Note that I did this quickly, so all messages say the same. If we want to improve it, we could point the various documents to their respective resources, but I don't have time to do that research right now. In any case, wanted to create this PR to show how we _could_ update this repo before archiving it.

Also, to note, @timbl, @rubensworks, and @csarven need to agree with Solid Team's decision on archiving this repo before moving on. For that reason, I'm requesting them as reviewers in this PR.